### PR TITLE
Hotfix: Correct construction of slack redirect uri

### DIFF
--- a/src/main/java/com/revature/services/UserService.java
+++ b/src/main/java/com/revature/services/UserService.java
@@ -107,7 +107,7 @@ public class UserService {
 		MultiValueMap<String, String> map= new LinkedMultiValueMap<>();
 		map.add("code", code);
 
-		map.add("redirect_uri", env.get("REFORCE_WEBCLIENT_URL") + "loading");
+		map.add("redirect_uri", env.get("REFORCE_WEBCLIENT_URL") + "/loading");
 		map.add("client_id", client_id);
 		map.add("client_secret", client_secret);
 


### PR DESCRIPTION
Previously would result in malformed redirect URI. If the environment variable "REFORCE_WEBCLIENT_URL" is set to "http://localhost:4200", the resulting redirect URI would become "http://localhost:4200loading" due to missing '/' character before "loading".

Fix is to add the '/' character into the URI construction. Result is similar to "http://localhost:4200/loading".